### PR TITLE
'+' in the query part of the URL

### DIFF
--- a/lib/uri.ml
+++ b/lib/uri.ml
@@ -93,6 +93,7 @@ module Generic : Scheme = struct
     (* '&' is safe but we should encode literals to avoid ambiguity
        with the already parsed qs params *)
     a.(Char.code '&') <- false;
+    a.(Char.code '+') <- false;
     a
 
   let safe_chars_for_query_key : safe_chars =


### PR DESCRIPTION
Hi Anil,

I added '+' as a character to percent-encode when it occurs in the query, for compatibility with application/x-www-form-urlencoded which assumes that '+' means space.

This solves our problem, since we had something like

  http://example.com/?content_md5=H9vmjmollvcyz9M14i+S0w== (incorrect)

now it is:

  http://example.com/?content_md5=H9vmjmollvcyz9M14i%2BS0w==
