### PR TITLE
Make `Uri.with_port` not set hostname if it is trying to unset a port

### DIFF
--- a/lib/uri.ml
+++ b/lib/uri.ml
@@ -687,8 +687,12 @@ let with_userinfo uri userinfo =
 let port uri = uri.port
 let with_port uri port =
   match host uri with
-  | None -> { uri with host=Some (Pct.cast_decoded ""); port=port }
   | Some _ -> { uri with port=port }
+  | None -> begin
+     match port with
+     | None -> { uri with host=None; port=None }
+     | Some _ -> { uri with host=Some (Pct.cast_decoded ""); port=port }
+  end
 
 (* Return the path component *)
 let path uri = Pct.uncast_encoded (match uri.scheme with

--- a/lib_test/test_runner.ml
+++ b/lib_test/test_runner.ml
@@ -449,7 +449,8 @@ let test_with_change =
     let foo_port = Uri.with_port foo (Some 80) in
     assert_equal (Uri.of_string "http://foo.com:80") foo_port;
     let uri_no_port = Uri.with_port foo_port None in
-    assert_equal foo uri_no_port
+    assert_equal foo uri_no_port;
+    assert_equal (Uri.of_string "/") (Uri.with_port (Uri.of_string "/") None)
   );
 
   "test_with_path" >:: (fun () ->


### PR DESCRIPTION
This makes the following two statements identical:

    Uri.with_port (Uri.of_string "/") None
    Uri.of_string "/"