### PR TITLE
Add verbatim_query for extracting literal query string. Fixes #57.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@
 * Uri_services now includes service aliases (e.g. www, www-http, http)
 * Uri_services now includes chargen and git
 * Add `Uri.canonicalize` for scheme-specific normalization (#70)
+* Add `Uri.verbatim_query` to extract literal query string (#57)
+* Add `Uri.equal`
 * Add `Uri.user` and `Uri.password` accessors for subcomponents of userinfo (#62)
 * Add `Uri.with_password` functional setter for password subcomponent of userinfo
 * Fix file scheme host normalization bug which introduced empty host (#59)

--- a/lib/uri.mli
+++ b/lib/uri.mli
@@ -43,6 +43,9 @@ val empty : t
     and finally fragment. Designed to produce a reasonable sort order. *)
 val compare : t -> t -> int
 
+(** [equal a b] is [compare a b = 0]. *)
+val equal : t -> t -> bool
+
 (** Percent-encode a string. The [scheme] argument defaults to 'http' and
     the [component] argument defaults to `Path *)
 val pct_encode : ?scheme:string -> ?component:component -> string -> string
@@ -99,6 +102,12 @@ val make : ?scheme:string -> ?userinfo:string -> ?host:string ->
 
 (** Get a query string from a URI *)
 val query : t -> (string * string list) list
+
+(** Get a verbatim query string from a URI. If the provenance of the
+    URI is a string and its query component has not been updated, this
+    is the literal query string as parsed. Otherwise, this is the
+    composition of {!query} and {!encoded_of_query} *)
+val verbatim_query : t -> string option
 
 (** Make a percent-encoded query string from percent-decoded query tuple *)
 val encoded_of_query : ?scheme:string -> (string * string list) list -> string


### PR DESCRIPTION
Also add `Uri.equal` convenience function as polymorphic equality now has surprising behavior when modified URIs are compared with verbatim URIs.