### PR TITLE
whitespace; documentation tweak

### DIFF
--- a/lib/uri.ml
+++ b/lib/uri.ml
@@ -60,7 +60,7 @@ let rec compare_list f t t' = match t, t' with
   | x::xs, y::ys ->
     match f x y with 0 -> compare_list f xs ys | c -> c
 
-(** Safe characters that are always allowed in a URI 
+(** Safe characters that are always allowed in a URI
   * Unfortunately, this varies depending on which bit of the URI
   * is being parsed, so there are multiple variants (and this
   * set is probably not exhaustive. TODO: check.
@@ -83,7 +83,7 @@ module Generic : Scheme = struct
     done;
     a
 
-  let safe_chars : safe_chars = 
+  let safe_chars : safe_chars =
     let a = Array.make 256 false in
     let always_safe =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-~" in
@@ -215,10 +215,10 @@ let module_of_scheme = function
   * and this really, really shouldn't be mixed up. So this Pct module
   * defines abstract Pct.encoded and Pct.decoded types which sets the
   * state of the underlying string.  There are functions to "cast" to
-  * and from these and normal strings, and this promotes a bit of 
-  * internal safety.  These types are not exposed to the external 
+  * and from these and normal strings, and this promotes a bit of
+  * internal safety.  These types are not exposed to the external
   * interface, as casting to-and-from is quite a bit of hassle and
-  * probably not a lot of use to the average consumer of this library 
+  * probably not a lot of use to the average consumer of this library
 *)
 module Pct : sig
   type encoded [@@deriving sexp]
@@ -255,7 +255,7 @@ end = struct
   let unlift_decoded f = f
   let unlift_decoded2 f = f
 
-  (** Scan for reserved characters and replace them with 
+  (** Scan for reserved characters and replace them with
       percent-encoded equivalents.
       @return a percent-encoded string *)
   let encode ?scheme ?(component=`Path) b =

--- a/lib/uri.mli
+++ b/lib/uri.mli
@@ -53,7 +53,10 @@ val pct_encode : ?scheme:string -> ?component:component -> string -> string
 (** Percent-decode a percent-encoded string *)
 val pct_decode : string -> string
 
-(** Parse a URI string literal into a URI structure *)
+(** Parse a URI string literal into a URI structure. A bare string will be
+    interpreted as a path; a string prefixed with `//` will be interpreted as a
+    host.
+*)
 val of_string : string -> t
 
 (** Convert a URI structure into a percent-encoded URI string *)

--- a/lib/uri.mli
+++ b/lib/uri.mli
@@ -22,15 +22,15 @@
 type t [@@deriving sexp]
 
 type component = [
-  `Scheme
-| `Authority
-| `Userinfo (** subcomponent of authority in some schemes *)
-| `Host (** subcomponent of authority in some schemes *)
-| `Path
-| `Query
-| `Query_key
-| `Query_value
-| `Fragment
+    `Scheme
+  | `Authority
+  | `Userinfo (** subcomponent of authority in some schemes *)
+  | `Host (** subcomponent of authority in some schemes *)
+  | `Path
+  | `Query
+  | `Query_key
+  | `Query_value
+  | `Fragment
 ] [@@deriving sexp]
 
 (** {3 Core functionality } *)
@@ -117,27 +117,27 @@ val query_of_encoded : string -> (string * string list) list
 
 (** Replace the query URI with the supplied list.
     Input URI is not modified
-  *)
+*)
 val with_query : t -> (string * string list) list -> t
 
 (** Replace the query URI with the supplied singleton query list.
     Input URI is not modified
-  *)
+*)
 val with_query' : t -> (string * string) list -> t
 
 (** [get_query_param' q key] returns the list of values for the
     [key] parameter in query [q].  Note that an empty list is not the
     same as a [None] return value.  For a query [foo], the mapping is:
-- [/] returns None
-- [/?foo] returns Some []
-- [/?foo=] returns [Some [""]]
-- [/?foo=bar] returns [Some ["bar"]]
-- [/?foo=bar,chi] returns [Some ["bar","chi"]]
+    - [/] returns None
+    - [/?foo] returns Some []
+    - [/?foo=] returns [Some [""]]
+    - [/?foo=bar] returns [Some ["bar"]]
+    - [/?foo=bar,chi] returns [Some ["bar","chi"]]
 
     Query keys can be duplicated in the URI, in which case the first
     one is returned.  If you want to resolve duplicate keys, obtain
     the full result set with {! query } instead.
-  *)
+*)
 val get_query_param' : t -> string -> string list option
 
 (** [get_query_param q key] returns the value found for a [key] in
@@ -147,28 +147,28 @@ val get_query_param: t -> string -> string option
 
 (** Add a query parameter to the input query URI.
     Input URI is not modified
-  *)
+*)
 val add_query_param : t -> (string * string list) -> t
 
 (** Add a query parameter to the input singleton query URI.
     Input URI is not modified
-  *)
+*)
 val add_query_param' : t -> (string * string) -> t
 
 (** Add a query parameter list to the input query URI.
     Input URI is not modified
-  *)
+*)
 val add_query_params : t -> (string * string list) list -> t
 
 (** Add a query singleton parameter list to the input query URI.
     Input URI is not modified
-  *)
+*)
 val add_query_params' : t -> (string * string) list -> t
 
 (** Remove a query key from the input query URI.
     Input URI is not modified, and no error is generated if the
     key does not already exist in the URI.
-  *)
+*)
 val remove_query_param : t -> string -> t
 
 (** {3 Component getters and setters } *)

--- a/lib_test/test_runner.ml
+++ b/lib_test/test_runner.ml
@@ -20,7 +20,7 @@ open OUnit
 open Printf
 
 (* Tuples of decoded and encoded strings. The first element is a number to
-   refer to the test, as the pcts_large version duplicates the second field 
+   refer to the test, as the pcts_large version duplicates the second field
    to a large size, so it cant be used as the name of the test *)
 let pcts = [
   (1, "hello world!", "hello%20world!");
@@ -46,7 +46,7 @@ let pcts_large =
     done;
     (n, Buffer.contents a', Buffer.contents b')
   ) pcts
- 
+
 (* Tuple of string URI and the decoded version *)
 let uri_encodes = [
   "https://user:pass@foo.com:123/wh/at/ever?foo=1&bar=5#5",
@@ -86,7 +86,7 @@ let map_pcts_tests size name test args =
   ) args
 
 let test_pct_small =
-  (map_pcts_tests "small" "encode" (fun a b -> b, (Uri.pct_encode a)) pcts) @ 
+  (map_pcts_tests "small" "encode" (fun a b -> b, (Uri.pct_encode a)) pcts) @
   (map_pcts_tests "small" "decode" (fun a b -> (Uri.pct_decode b), a) pcts)
 
 let test_pct_large =
@@ -663,4 +663,3 @@ let _ =
     ("Usage: " ^ Sys.argv.(0) ^ " [-verbose]");
   if not (was_successful (run_test_tt ~verbose:!verbose suite)) then
   exit 1
-


### PR DESCRIPTION
Some (ocp-indent) whitespace things because my emacs cares, plus a tweak to a documentation comment for `of_string` as it surprised me just now.
