### PR TITLE
add ppx_deriving dependency

### DIFF
--- a/opam
+++ b/opam
@@ -25,6 +25,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ounit" {test & >= "1.0.2"}
+  "ppx_deriving"
   "ppx_sexp_conv" {>= "113.33.01"}
   "re"
   "sexplib" {>= "109.53.00"}


### PR DESCRIPTION
New version of Core makes ppx_deriving optional. This breaks ocaml-uri.