### PR TITLE
Update README, restrict to OCaml 4.03.0 or higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,15 @@ script: bash ./.travis-docker.sh
 env:
  global:
    - PACKAGE="uri"
-   - PRE_INSTALL_HOOK="OPAMYES=true opam install ocaml-migrate-parsetree"
    - POST_INSTALL_HOOK="OPAMYES=true opam depext -i react ssl lwt"
    - REVDEPS="cohttp git github irmin sociaml-facebook-api sociaml-oauth-client sociaml-tumblr-api spotify-web-api syndic"
  matrix:
-   - DISTRO=debian-stable OCAML_VERSION=4.02.3
+   - DISTRO=debian-stable OCAML_VERSION=4.03.0
    - DISTRO=debian-testing OCAML_VERSION=4.03.0
    - DISTRO=debian-unstable OCAML_VERSION=4.04.0
-   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.02.3
+   - DISTRO=ubuntu-12.04 OCAML_VERSION=4.03.0
    - DISTRO=ubuntu-16.04 OCAML_VERSION=4.04.0
    - DISTRO=centos-6 OCAML_VERSION=4.03.0
    - DISTRO=centos-7 OCAML_VERSION=4.03.0
-   - DISTRO=fedora-25 OCAML_VERSION=4.02.3
+   - DISTRO=fedora-25 OCAML_VERSION=4.03.0
    - DISTRO=alpine OCAML_VERSION=4.04.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 1.9.4 (2017-05-22):
 * Port build system to jbuilder (#100 @vbmithr @rgrinberg @avsm @dsheets)
+* Restrict build to OCaml 4.03.0+ (was formerly OCaml 4.02.0+).
 
 1.9.3 (2017-03-06):
 * Port build system to topkg (#95 by @fgimenez)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,41 @@
-[RFC3986](http://tools.ietf.org/html/rfc3986) URI parsing library.
+Uri -- an RFC3986 URI/URL parsing library
+-----------------------------------------
 
-Build requirements:
-* [ocaml-re](http://github.com/avsm/ocaml-re) regular expression library.
-* [oUnit](http://ounit.forge.ocamlcore.org/) unit testing library.
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification 
+for parsing URI or URLs.
+
+## Installation
+
+### Via OPAM
+
+The [OPAM](https://opam.ocaml.org) package manager can be used to install this library from source.
+
+    opam install uri
+
+### Locally
+
+You can build the source code locally via the [Jbuilder](https://github.com/janestreet/jbuilder)
+build system.
+
+    opam install uri --deps-only
+    eval `opam config env`
+    jbuilder build --dev
+    jbuilder runtest
+
+will install the dependencies via OPAM, build the library and then run the tests in the [lib_test/](lib_test/) directory.
+
+## Usage
+
+Once installed, there are three ocamlfind packages available for your use:
+
+- `uri` - the base `Uri` module
+- `uri.top` - the toplevel printers for use with [utop](https://github.com/diml/utop)
+- `uri.services` - the `Uri_services` modules that provide the equivalent of *[services(5)](http://man7.org/linux/man-pages/man5/services.5.html)*
+
+## Contact
+
+- Issues: <https://github.com/mirage/ocaml-uri/issues>
+- E-mail: <mirageos-devel@lists.xenproject.org>
+- API Documentation: <http://docs.mirage.io/uri/>
 
 [![Build Status](https://travis-ci.org/mirage/ocaml-uri.png)](https://travis-ci.org/mirage/ocaml-uri)

--- a/uri.opam
+++ b/uri.opam
@@ -27,4 +27,4 @@ depends: [
   "sexplib" {>= "109.53.00"}
   "stringext" {>= "1.4.0"}
 ]
-available: [ ocaml-version >= "4.02.2" ]
+available: [ ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
This is due to a transitive dependency on that version for ppx_sexp_conv using ppx_driver and ocaml-migrate-parsetree. Bumping the minimum version will also help with subsequent warning-elimination for (e.g.) the use of `String.lowercase`.
