### PR TITLE
prepare release 1.9.4: add topkg-jbuilder support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-1.9.4 (2017-05-22):
+1.9.4 (2017-05-26):
 * Port build system to jbuilder (#100 @vbmithr @rgrinberg @avsm @dsheets)
 * Restrict build to OCaml 4.03.0+ (was formerly OCaml 4.02.0+).
 

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,1 @@
+%%VERSION_NUM%%

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,0 +1,2 @@
+#use "topfind"
+#require "topkg-jbuilder.auto"

--- a/uri.opam
+++ b/uri.opam
@@ -15,12 +15,15 @@ tags: [
   "org:mirage"
   "org:xapi-project"
 ]
-build: [ "jbuilder" "build" "@install" ]
-build-test: [ "jbuilder" "build" "@runtest" ]
+build: [
+  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+build-test: [ "jbuilder" "runtest" "-p" name "-j" jobs ]
 depends: [
   "base-bytes"
   "ocamlfind" {build}
-  "jbuilder" {build}
+  "jbuilder" {build & >="1.0+beta7"}
   "ounit" {test & >= "1.0.2"}
   "ppx_sexp_conv" {>= "113.33.01"}
   "re"


### PR DESCRIPTION
- VERSION file is detected by jbuilder
- pkg/pkg.ml has topkg-jbuilder defaults
- uri.opam calls `jbuilder subst` to generate the archive