### PR TITLE
also set wrapped to be false in jbuilder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,12 @@
 v1.9.4 2017-05-30
 -----------------
 
-* Port build system to jbuilder (#100 @vbmithr @rgrinberg @avsm @dsheets)
+* Port build system to jbuilder (#100 @vbmithr @rgrinberg @avsm @dsheets).
+  There should be no observable changes, except that `Uri_services` is now
+  in a separate subdirectory. This means that packages that implicitly
+  depended on the module without including the ocamlfind `uri.services`
+  package may now fail. Just adding the ocamlfind dependency will fix it,
+  and is backwards compatible with older Uri releases.
 * Restrict build to OCaml 4.03.0+ (was formerly OCaml 4.02.0+).
 * Add Appveyor tests for Windows compilation.
 

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,6 +1,7 @@
 (library
  ((name        uri)
   (public_name uri)
+  (wrapped false)
   (modules (uri uri_re))
   (preprocess (pps (ppx_sexp_conv)))
   (libraries (sexplib re.posix stringext))))

--- a/uri.opam
+++ b/uri.opam
@@ -25,9 +25,9 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {build & >="1.0+beta7"}
   "ounit" {test & >= "1.0.2"}
-  "ppx_sexp_conv" {>= "113.33.01"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "re"
-  "sexplib" {>= "109.53.00"}
+  "sexplib" {>= "v0.9.0"}
   "stringext" {>= "1.4.0"}
 ]
 available: [ ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
This will rerelease 1.9.4 as it is more compatible with the older
layout. I've put a note into CHANGES about where to expect breakage.