### PR TITLE
silence warnings

### DIFF
--- a/etc/uri_services_raw.ml
+++ b/etc/uri_services_raw.ml
@@ -1,6 +1,6 @@
 let port_of_uri ?default lookupfn uri =
   match Uri.port uri with
-  |Some port as x -> x
+  |Some _port as x -> x
   |None -> begin
     match Uri.scheme uri, default with
     |None, None -> None

--- a/lib/uri_re.ml
+++ b/lib/uri_re.ml
@@ -15,6 +15,8 @@
  *
  *)
 
+[@@@ocaml.warning "-32"]
+
 open Re
 
 module Raw = struct


### PR DESCRIPTION
Compatibilty review: currently uri.opam requires (ocaml-version >= 4.03), and:
- "match .. with exception" and attributes appeared in 4.02
  (@ocaml.warning is only supported since 4.03)
- {String,Char}.{uppercase,lowercase}_ascii appeared in 4.03

A domain expert should review the use of _ascii functions, which may
change the program behavior: my understanding is that assuming latin1
encoding of URI and dealing with accented characters that way would be
wrong anyway.