### PR TITLE
Fix uri deps

### DIFF
--- a/config/jbuild
+++ b/config/jbuild
@@ -1,5 +1,7 @@
+(jbuild_version 1)
+
 (executable
   ((name "gen_services")
    (modules (gen_services))
-   (libraries (bytes stringext))
+   (libraries (stringext))
 ))

--- a/uri.opam
+++ b/uri.opam
@@ -21,12 +21,11 @@ build: [
 ]
 build-test: [ "jbuilder" "runtest" "-p" name "-j" jobs ]
 depends: [
-  "base-bytes"
-  "ocamlfind" {build}
   "jbuilder" {build & >="1.0+beta7"}
   "ounit" {test & >= "1.0.2"}
-  "ppx_sexp_conv" {build & >= "v0.9.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
   "re"
+  "ocaml-migrate-parsetree" {build}
   "sexplib" {>= "v0.9.0"}
   "stringext" {>= "1.4.0"}
 ]


### PR DESCRIPTION
ppx_sexp_conv contains the runtime it uses for >= 0.11.0. So to work with all
versions of ppx_sexp_conv we need to drop {build}. As it's only correct for
<0.11.0.

Also drop base-bytes as it's useless for ocaml >= 4.02

Would be great to have a prompt release with this. As this is causing broken builds.