### PR TITLE
Optional sexplib

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -3,8 +3,15 @@
   (public_name uri)
   (wrapped false)
   (modules (uri uri_re))
+  (libraries (re.posix stringext))))
+
+(library
+ ((name			uri_sexp)
+  (public_name	uri.sexp)
+  (wrapped false)
+  (modules (uri_sexp))
   (preprocess (pps (ppx_sexp_conv)))
-  (libraries (sexplib re.posix stringext))))
+  (libraries (sexplib uri))))
 
 (library
  ((name        uri_top)

--- a/lib/uri.ml
+++ b/lib/uri.ml
@@ -18,9 +18,6 @@
 
 [@@@ocaml.warning "-32"]
 
-open Sexplib.Std
-open Sexplib.Conv (* Workaround for bug in Sexplib when used without Core *)
-
 type component = [
   | `Scheme
   | `Authority
@@ -31,7 +28,7 @@ type component = [
   | `Query_key
   | `Query_value
   | `Fragment
-] [@@deriving sexp]
+]
 
 let rec iter_concat fn sep buf = function
   | last::[] -> fn buf last
@@ -223,8 +220,8 @@ let module_of_scheme = function
   * probably not a lot of use to the average consumer of this library
 *)
 module Pct : sig
-  type encoded [@@deriving sexp]
-  type decoded [@@deriving sexp]
+  type encoded
+  type decoded
 
   val encode : ?scheme:string -> ?component:component -> decoded -> encoded
   val decode : encoded -> decoded
@@ -243,8 +240,8 @@ module Pct : sig
   val unlift_decoded : (string -> string) -> decoded -> decoded
   val unlift_decoded2 : (string -> string -> 'a) -> decoded -> decoded -> 'a
 end = struct
-  type encoded = string [@@deriving sexp]
-  type decoded = string [@@deriving sexp]
+  type encoded = string
+  type decoded = string
   let cast_encoded x = x
   let cast_decoded x = x
   let empty_decoded = ""
@@ -341,7 +338,7 @@ let pct_decode s = Pct.(uncast_decoded (decode (cast_encoded s)))
 
 (* Userinfo string handling, to and from an id * credential pair *)
 module Userinfo = struct
-  type t = string * string option [@@deriving sexp]
+  type t = string * string option
 
   let compare (u,p) (u',p') =
     match String.compare u u' with
@@ -377,7 +374,7 @@ module Path = struct
   (* Yes, it's better this way. This means you can retain separator
      context in recursion (e.g. remove_dot_segments for relative resolution). *)
 
-  type t = string list [@@deriving sexp]
+  type t = string list
 
   let compare = compare_list String.compare
 
@@ -424,14 +421,11 @@ let encoded_of_path ?scheme = Path.encoded_of_path ?scheme
 (* Query string handling, to and from an assoc list of key/values *)
 module Query = struct
 
-  type kv = (string * string list) list [@@deriving sexp]
+  type kv = (string * string list) list
 
   type t =
     | KV of kv
     | Raw of string option * kv Lazy.t
-
-  let t_of_sexp sexp = KV (kv_of_sexp sexp)
-  let sexp_of_t = function Raw (_,lazy kv) | KV kv -> sexp_of_kv kv
 
   let compare x y = match x, y with
     | KV kvl, KV kvl'
@@ -511,14 +505,14 @@ let encoded_of_query ?scheme = Query.encoded_of_query ?scheme
 
 (* Type of the URI, with most bits being optional *)
 type t = {
-  scheme: Pct.decoded sexp_option;
-  userinfo: Userinfo.t sexp_option;
-  host: Pct.decoded sexp_option;
-  port: int sexp_option;
+  scheme: Pct.decoded option;
+  userinfo: Userinfo.t option;
+  host: Pct.decoded option;
+  port: int option;
   path: Path.t;
   query: Query.t;
-  fragment: Pct.decoded sexp_option;
-} [@@deriving sexp]
+  fragment: Pct.decoded option;
+}
 
 let empty = {
   scheme = None;

--- a/lib/uri.mli
+++ b/lib/uri.mli
@@ -19,7 +19,7 @@
 
 (** A single URI that is a compact sequence of characters that identifies
     an abstract or physical resource. *)
-type t [@@deriving sexp]
+type t
 
 type component = [
     `Scheme
@@ -31,7 +31,7 @@ type component = [
   | `Query_key
   | `Query_value
   | `Fragment
-] [@@deriving sexp]
+]
 
 (** {3 Core functionality } *)
 

--- a/lib/uri_sexp.ml
+++ b/lib/uri_sexp.ml
@@ -1,0 +1,59 @@
+open Uri
+
+module Derived =
+struct
+
+	open Sexplib.Std
+	open Sexplib.Conv
+
+	type component = [
+	  | `Scheme
+	  | `Authority
+	  | `Userinfo (* subcomponent of authority in some schemes *)
+	  | `Host (* subcomponent of authority in some schemes *)
+	  | `Path
+	  | `Query
+	  | `Query_key
+	  | `Query_value
+	  | `Fragment
+	] [@@deriving sexp]
+
+	type t = {
+	  s_scheme: string sexp_option;
+	  s_userinfo: string sexp_option;
+	  s_host: string sexp_option;
+	  s_port: int sexp_option;
+	  s_path: string;
+	  s_query: (string * string list) list;
+	  s_fragment: string sexp_option
+	} [@@deriving sexp]
+
+end
+
+open Derived
+
+let component_of_sexp = component_of_sexp
+let sexp_of_component = sexp_of_component
+
+let t_of_sexp sexp =
+	let t = t_of_sexp sexp in
+	Uri.make
+		?scheme:t.s_scheme
+		?userinfo:t.s_userinfo
+		?host:t.s_host
+		?port:t.s_port
+		~path:t.s_path
+		~query:t.s_query
+		?fragment:t.s_fragment
+		()
+
+let sexp_of_t t =
+	sexp_of_t {
+		s_scheme = scheme t;
+		s_userinfo = userinfo t;
+		s_host = host t;
+		s_port = port t;
+		s_path = path t;
+		s_query = query t;
+		s_fragment = fragment t
+	}

--- a/lib/uri_sexp.mli
+++ b/lib/uri_sexp.mli
@@ -1,0 +1,6 @@
+open Sexplib
+
+val component_of_sexp : Sexp.t -> Uri.component
+val sexp_of_component : Uri.component -> Sexp.t
+val t_of_sexp : Sexp.t -> Uri.t
+val sexp_of_t : Uri.t -> Sexp.t

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -1,6 +1,6 @@
 (executables
  ((names (test_runner))
-  (libraries (uri uri_services oUnit))))
+  (libraries (uri uri.sexp uri_services oUnit sexplib))))
 
 (alias
  ((name    runtest)

--- a/lib_test/test_runner.ml
+++ b/lib_test/test_runner.ml
@@ -405,7 +405,7 @@ let test_sexping =
   ] in
   let test uri exp =
     let uri = Uri.of_string uri in
-    let s = Sexplib.Sexp.to_string (Uri.sexp_of_t uri) in
+    let s = Sexplib.Sexp.to_string (Uri_sexp.sexp_of_t uri) in
     let msg = sprintf "%s <> %s" s exp in
     assert_equal ~msg s exp
   in
@@ -529,8 +529,8 @@ let test_with_change = [
     let uri_some = Uri.with_path uri "a" in
     let uri_exp_s = "///a" in
     let uri_exp = Uri.of_string uri_exp_s in
-    let uri_exp_sexp  = Sexplib.Sexp.to_string (Uri.sexp_of_t uri_exp) in
-    let uri_some_sexp = Sexplib.Sexp.to_string (Uri.sexp_of_t uri_some) in
+    let uri_exp_sexp  = Sexplib.Sexp.to_string (Uri_sexp.sexp_of_t uri_exp) in
+    let uri_some_sexp = Sexplib.Sexp.to_string (Uri_sexp.sexp_of_t uri_some) in
     let msg = sprintf "path relative host (%s <> %s)"
       uri_exp_sexp uri_some_sexp in
     assert_equal ~msg uri_exp uri_some
@@ -546,8 +546,8 @@ let test_with_change = [
       let uri_quest = Uri.with_query uri ["",[]] in
       let uri_exp_s = prefix ^ "?" in
       let uri_exp   = Uri.of_string uri_exp_s in
-      let uri_exp_sexp = Sexplib.Sexp.to_string (Uri.sexp_of_t uri_exp) in
-      let uri_quest_sexp = Sexplib.Sexp.to_string (Uri.sexp_of_t uri_quest) in
+      let uri_exp_sexp = Sexplib.Sexp.to_string (Uri_sexp.sexp_of_t uri_exp) in
+      let uri_quest_sexp = Sexplib.Sexp.to_string (Uri_sexp.sexp_of_t uri_quest) in
       let msg = sprintf "'%s' quest (%s <> %s)"
         prefix uri_exp_sexp uri_quest_sexp in
       assert_equal ~cmp ~msg uri_exp uri_quest;


### PR DESCRIPTION
Make sexplib optional by moving sexp conversions to the `uri.sexp` library

Sexp conversions are reimplemented with different internal types, compatibility is broken

Deriving sexp added a lot of dependencies that were problematic in my used case (js_of_ocaml)