### PR TITLE
Drop sexplib in favour of sexplib0

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -4,7 +4,7 @@
   (wrapped false)
   (modules (uri uri_re))
   (preprocess (pps (ppx_sexp_conv)))
-  (libraries (sexplib re.posix stringext))))
+  (libraries (re.posix sexplib0 stringext))))
 
 (library
  ((name        uri_top)

--- a/lib/uri.ml
+++ b/lib/uri.ml
@@ -18,8 +18,7 @@
 
 [@@@ocaml.warning "-32"]
 
-open Sexplib.Std
-open Sexplib.Conv (* Workaround for bug in Sexplib when used without Core *)
+open Sexplib0.Sexp_conv
 
 type component = [
   | `Scheme

--- a/lib_test/test_runner.ml
+++ b/lib_test/test_runner.ml
@@ -405,7 +405,7 @@ let test_sexping =
   ] in
   let test uri exp =
     let uri = Uri.of_string uri in
-    let s = Sexplib.Sexp.to_string (Uri.sexp_of_t uri) in
+    let s = Sexplib0.Sexp.to_string (Uri.sexp_of_t uri) in
     let msg = sprintf "%s <> %s" s exp in
     assert_equal ~msg s exp
   in
@@ -529,8 +529,8 @@ let test_with_change = [
     let uri_some = Uri.with_path uri "a" in
     let uri_exp_s = "///a" in
     let uri_exp = Uri.of_string uri_exp_s in
-    let uri_exp_sexp  = Sexplib.Sexp.to_string (Uri.sexp_of_t uri_exp) in
-    let uri_some_sexp = Sexplib.Sexp.to_string (Uri.sexp_of_t uri_some) in
+    let uri_exp_sexp  = Sexplib0.Sexp.to_string (Uri.sexp_of_t uri_exp) in
+    let uri_some_sexp = Sexplib0.Sexp.to_string (Uri.sexp_of_t uri_some) in
     let msg = sprintf "path relative host (%s <> %s)"
       uri_exp_sexp uri_some_sexp in
     assert_equal ~msg uri_exp uri_some
@@ -546,8 +546,8 @@ let test_with_change = [
       let uri_quest = Uri.with_query uri ["",[]] in
       let uri_exp_s = prefix ^ "?" in
       let uri_exp   = Uri.of_string uri_exp_s in
-      let uri_exp_sexp = Sexplib.Sexp.to_string (Uri.sexp_of_t uri_exp) in
-      let uri_quest_sexp = Sexplib.Sexp.to_string (Uri.sexp_of_t uri_quest) in
+      let uri_exp_sexp = Sexplib0.Sexp.to_string (Uri.sexp_of_t uri_exp) in
+      let uri_quest_sexp = Sexplib0.Sexp.to_string (Uri.sexp_of_t uri_quest) in
       let msg = sprintf "'%s' quest (%s <> %s)"
         prefix uri_exp_sexp uri_quest_sexp in
       assert_equal ~cmp ~msg uri_exp uri_quest;

--- a/uri.opam
+++ b/uri.opam
@@ -25,7 +25,7 @@ depends: [
   "ounit" {test & >= "1.0.2"}
   "ppx_sexp_conv" {build & >= "v0.9.0"}
   "re" {>="1.7.2"}
-  "sexplib" {>= "v0.9.0"}
+  "sexplib0" {>= "v0.11.0"}
   "stringext" {>= "1.4.0"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+available: [ ocaml-version >= "4.04.1" ]


### PR DESCRIPTION
This is smaller and already provided by `ppx_sexp_conv.runtime-lib`
when using recent version of `ppx_sexp_conv`. It will allow to drop
the dependency on the much larger `sexplib` in a number of packages.
The price to pay is that `sexplib0` requires at least `ocaml-4.04.1`.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>