### PR TITLE
uri.top: depend on compiler-libs, not compiler-libs.toplevel

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -16,4 +16,4 @@
  (name        uri_top)
   (public_name uri.top)
   (modules uri_top)
-  (libraries uri compiler-libs.toplevel))
+  (libraries uri compiler-libs))


### PR DESCRIPTION
Fixes #129 