### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/uri-sexp.opam
+++ b/uri-sexp.opam
@@ -13,7 +13,7 @@ ocaml-uri with sexp support
 """
 depends: [
   "uri" {= version}
-  "dune" {build & >= "1.2.0"}
+  "dune" {>= "1.2.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib0"
   "ounit" {with-test}

--- a/uri.opam
+++ b/uri.opam
@@ -14,7 +14,7 @@ for parsing URI or URLs.
 """
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build & >= "1.2.0"}
+  "dune" {>= "1.2.0"}
   "ounit" {with-test & >= "1.0.2"}
   "ppx_sexp_conv" {with-test & >= "v0.9.0"}
   "re" {>= "1.9.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.