### PR TITLE
Add a message about deprecation of uri-re

### DIFF
--- a/uri-re.opam
+++ b/uri-re.opam
@@ -25,3 +25,4 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
+messages: [ "Deprecated. This package is outdated, you should consider using uri instead" ]


### PR DESCRIPTION
According to #150 and ocaml/opam#2046, I added a message to deprecate `uri-re` which will appear at the **next** release of `uri`.