### PR TITLE
Custom percent-encoders: don't mutate base encoder

### DIFF
--- a/lib/uri.ml
+++ b/lib/uri.ml
@@ -164,7 +164,7 @@ module Generic : Scheme = struct
     | `Fragment -> safe_chars_for_fragment
     | `Scheme -> safe_chars_for_scheme
     | `Custom ((component : component), safe, unsafe) ->
-       let safe_chars = safe_chars_for_component component in
+       let safe_chars = Array.copy (safe_chars_for_component component) in
        for i = 0 to String.length safe - 1 do
          let c = Char.code safe.[i] in
          safe_chars.(c) <- true


### PR DESCRIPTION
At the moment, [`` `Custom`` ](https://github.com/mirage/ocaml-uri/blob/b4a8375d9352d29ff495d35fc309609fad74631a/lib/uri.mli#L35) mutates the safe character array of its underlying component kind:

https://github.com/mirage/ocaml-uri/blob/b4a8375d9352d29ff495d35fc309609fad74631a/lib/uri.ml#L166-L176

This was added in #147. I'm not sure if this is intentional or not (cc @orbitz). I am currently abusing `` `Custom`` to build IRI-like percent encoders from existing component kinds (as a workaround for lack of #34). I don't want to modify the underlying encoders, though &mdash; I'd like both IRI and ASCII-only support for my own code, and, in addition, I fear about violating the assumptions of other code linked into the program.