### PR TITLE
Setup uri-bench to build benchmarking code.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,24 +11,33 @@ jobs:
       matrix:
         os:
           - macos-latest
-        ocaml-version:
-          - 4.12.0
-          - 4.11.1
-          - 4.10.0
-          - 4.09.1
-          - 4.08.2
+        ocaml-compiler:
+          - 5.0
+          - 4.14.1
+          - 4.13.1
+          - 4.08.1
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+        uses: actions/checkout@v3
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ matrix.ocaml-version }}
-      - run: opam pin add . --no-action
-      - run: opam depext uri uri-sexp uri-re --yes --with-doc --with-test
-      - run: opam install . --deps-only --with-doc --with-test
-      - run: opam exec -- dune build
-      - run: opam exec -- dune runtest
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+      - name: Install dependencies
+        run: |
+          opam install . --deps-only --with-test
+
+      - name: Build
+        run: |
+          opam exec -- dune build
+
+      - name: Tests
+        run: |
+          opam exec -- dune build @runtest
+
+      - name: Opam Lint
+        run: |
+          opam lint uri.opam uri-re.opam uri-sexp.opam uri-bench.opam

--- a/benchmarks/benchmark.ml
+++ b/benchmarks/benchmark.ml
@@ -1,5 +1,5 @@
 open Core
-open Core_bench.Std
+open Core_bench
 
 let make_bench_parsing (name, str) =
   Bench.Test.create ~name
@@ -30,4 +30,6 @@ let benchmarks = [
     (List.map ~f:make_bench_parsing parsing_benchs);
 ]
 
-let () = Command.run (Bench.make_command benchmarks)
+let () = 
+  Bench.make_command benchmarks
+  |> Command_unix.run

--- a/benchmarks/dune
+++ b/benchmarks/dune
@@ -1,6 +1,8 @@
 (executables
  (names benchmark)
- (libraries uri core_bench))
+ (package uri-bench)
+ (public_names uri-bench)
+ (libraries uri core_bench core_unix.command_unix))
 
 (alias
  (name bench)

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,11 +1,17 @@
-(executable
- (name fuzz)
- (libraries uri uri-re uri-sexp crowbar fmt))
+; (executable
+;  (name fuzz)
+;  (libraries uri uri-re uri-sexp crowbar))
 
-(alias
- (name fuzz)
- (deps fuzz.exe (source_tree input))
- (action (run
-    timeout --preserve-status 50m
-    bun -v --input=input --output=output -s
-    -- ./fuzz.exe)))
+; (alias
+;  (name fuzz)
+;  (deps fuzz.exe (source_tree input))
+;  (action (run
+;     timeout --preserve-status 50m
+;     bun -v --input=input --output=output -s
+;     -- ./fuzz.exe)))
+
+(tests
+ (names fuzz)
+ (package uri)
+ (libraries uri uri-re crowbar)
+ (deps (source_tree input)))

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,15 +1,3 @@
-; (executable
-;  (name fuzz)
-;  (libraries uri uri-re uri-sexp crowbar))
-
-; (alias
-;  (name fuzz)
-;  (deps fuzz.exe (source_tree input))
-;  (action (run
-;     timeout --preserve-status 50m
-;     bun -v --input=input --output=output -s
-;     -- ./fuzz.exe)))
-
 (tests
  (names fuzz)
  (package uri)

--- a/uri-bench.opam
+++ b/uri-bench.opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "Benchmarking package for ocaml-uri"
+description: """
+This is a benchmarking package for the OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "uri" {= version}
+  "core_bench" {with-test}
+  "core_unix" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]

--- a/uri-bench.opam
+++ b/uri-bench.opam
@@ -15,8 +15,8 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.2.0"}
   "uri" {= version}
-  "core_bench" {with-test}
-  "core_unix" {with-test}
+  "core_bench" {with-test & >= "v0.14.0"}
+  "core_unix" {with-test & >= "v0.14.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/uri.opam
+++ b/uri.opam
@@ -17,6 +17,7 @@ depends: [
   "dune" {>= "1.2.0"}
   "ounit" {with-test & >= "1.0.2"}
   "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "crowbar" {with-test & >= "0.2"}
   "stringext" {>= "1.4.0"}
   "angstrom" {>= "0.14.0"}
 ]


### PR DESCRIPTION
Fix for https://github.com/mirage/ocaml-uri/issues/165


* 521946200f7c866b3b69aeb47221cb19c4835141 adds a new package uri-bench that includes the benchmarking code and dependencies.
* ca5f72aa8f80f288abdaea392ce0529b3d3848f7 attaches the fuzzer tests to uri package, note they also rely on the deprecated uri-re package. 
* 370c6d42bbcaed3c7b73ebf7b050bff2f60faa7d updates the GitHub Actions tests. Note it restricts to OCaml versions 4.08 - 5.0 due to test dependencies not supporting earlier versions down to 4.04. Can versions before 4.08 be dropped from the opam files?