### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ Once installed, there are three ocamlfind packages available for your use:
 
 - Issues: <https://github.com/mirage/ocaml-uri/issues>
 - E-mail: <mirageos-devel@lists.xenproject.org>
-- API Documentation: <http://docs.mirage.io/uri/>
+- API Documentation: <https://ocaml.org/p/uri/latest/doc/index.html>
 
 [![Build Status](https://travis-ci.org/mirage/ocaml-uri.png)](https://travis-ci.org/mirage/ocaml-uri)


### PR DESCRIPTION
Unsure if it's broken but docs.mirage.io points to opam docs, so better to point the correct path (which is up)