### PR TITLE
Add path_unencoded function

### DIFF
--- a/lib/uri.ml
+++ b/lib/uri.ml
@@ -438,6 +438,12 @@ module Path = struct
     ) "" buf p;
     Pct.cast_encoded (Buffer.contents buf)
 
+  let decoded_of_path p =
+    let len = List.fold_left (fun c tok -> String.length tok + c) 0 p in
+    let buf = Buffer.create len in
+    iter_concat (fun buf s -> Buffer.add_string buf s) "" buf p;
+    Pct.cast_decoded (Buffer.contents buf)
+
   (* Subroutine for resolve <http://tools.ietf.org/html/rfc3986#section-5.2.3> *)
   let merge bhost bpath relpath =
     match bhost, List.rev bpath with
@@ -448,6 +454,7 @@ end
 
 let path_of_encoded = Path.path_of_encoded
 let encoded_of_path ?scheme ~component = Path.encoded_of_path ?scheme ~component
+let decoded_of_path = Path.decoded_of_path
 
 (* Query string handling, to and from an assoc list of key/values *)
 module Query = struct
@@ -753,6 +760,8 @@ let with_path uri path =
   match host uri, path with
   | None, _ | Some _, "/"::_ | Some _, [] -> { uri with path=path }
   | Some _, _  -> { uri with path="/"::path }
+
+let path_unencoded uri = Pct.uncast_decoded (decoded_of_path uri.path)
 
 let fragment uri = get_decoded_opt uri.fragment
 let with_fragment uri =

--- a/lib/uri.mli
+++ b/lib/uri.mli
@@ -211,6 +211,9 @@ val path : ?pct_encoder:pct_encoder -> t -> string
 (** Get the encoded path and query components of a URI *)
 val path_and_query : t -> string
 
+(** Get the unencoded path component of a URI *)
+val path_unencoded : t -> string
+
 (** Replace the path URI with the supplied encoded path.
     If a host is present in the supplied URI, the path is made absolute but not
     resolved. If the path is empty, the path component is removed.


### PR DESCRIPTION
This is intended less as the suggested implementation (it simply follows the existing `encoded_of_path` one), but as a starting point for a discussion to include such function.

Its addition is motivated by several things:
* To make `.path` interface similar to that of `.query`, which has both the encoded (verbatim) and the unencoded (default) version
* To avoid unnecessary encoding->decoding that is required now to obtain an unencoded path like: `Uri.path x |> Uri.pct_decode`
* It seems to be hard to achieve this through the existing interface of `path ?pct_encoder`, since the encoder relies on the list of safe characters - makes little sense to create a whitelist of all characters for this.